### PR TITLE
Added git gui blame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Git Tools
 
-Simple tool to open Git Gui and Gitk in Atom.
+Simple tool to open Git Gui, Gitk and Git Blame in Atom.
 
 It runs on Linux and can run on OS X.
+(Seems also to run on Windows 10 without problems).
 
-Requires you to install [git-gui](https://git-scm.com/docs/git-gui) and [gitk](https://git-scm.com/docs/gitk).
+Requires you to install
+   - [git-gui](https://git-scm.com/docs/git-gui),
+   - [gitk](https://git-scm.com/docs/gitk) and
+   - [git-blame](https://git-scm.com/docs/git-blame)

--- a/lib/git-tools.coffee
+++ b/lib/git-tools.coffee
@@ -10,6 +10,8 @@ module.exports = GitTools =
     @subscriptions.add
     atom.commands.add 'atom-workspace', 'git-tools:git-gui': => @git_gui()
     @subscriptions.add
+    atom.commands.add 'atom-workspace', 'git-tools:git-gui-blame': => @git_gui_blame()
+    @subscriptions.add
     atom.commands.add 'atom-workspace', 'git-tools:gitk': => @git_k()
     @subscriptions.add
     atom.commands.add(
@@ -26,7 +28,18 @@ module.exports = GitTools =
 
   file: ->
     editor = atom.workspace.getActivePaneItem()
-    editor?.buffer.file?.path
+    if editor == undefined
+      undefined
+    else
+      editor?.buffer.file?.path
+
+  line: ->
+    editor = atom.workspace.getActiveTextEditor()
+    if editor == undefined
+      undefined
+    else
+      editor?.getCursorScreenPosition().row + 1
+
 
   isUndefined: (dir, title) ->
     if dir == undefined
@@ -53,3 +66,13 @@ module.exports = GitTools =
     dir = @dir()
     return if @isUndefined(dir, "Git Gui")
     exec 'cd ' + dir + ' && git gui'
+
+  git_gui_blame: ->
+    dir = @dir()
+    file = @file()
+    line = @line()
+
+    return if @isUndefined(file, "Git Gui Blame")
+    return if @isUndefined(line, "Git Gui Blame")
+
+    exec 'cd ' + dir + ' && git gui blame --line=' + line + ' ' + '""' + file + '""'

--- a/lib/git-tools.coffee
+++ b/lib/git-tools.coffee
@@ -19,6 +19,12 @@ module.exports = GitTools =
       'git-tools:gitk-current-file': => @git_k_cf()
     )
 
+    # Subscribe to the event when the multiple cursor notification config is modified
+    @subscriptions.add atom.config.onDidChange 'git-tools.blameCursorNotification', =>
+      @blameCursorNotification = atom.config.get('git-tools.blameCursorNotification')
+
+    @blameCursorNotification = atom.config.get('git-tools.blameCursorNotification')
+    
   dir: ->
     editor = atom.workspace.getActivePaneItem()
     if editor == undefined
@@ -38,8 +44,16 @@ module.exports = GitTools =
     if editor == undefined
       undefined
     else
-      editor?.getCursorScreenPosition().row + 1
-
+      line = editor.getCursorScreenPosition().row + 1
+      if editor.hasMultipleCursors() && @blameCursorNotification
+         atom.notifications.addInfo(
+            'Git Gui Blame',
+            {
+               detail: 'Position could not be resolved due multiple cursors.\nLine (used): ' + line
+               dismissable: true
+            }
+         )
+      line
 
   isUndefined: (dir, title) ->
     if dir == undefined

--- a/menus/git-tools.cson
+++ b/menus/git-tools.cson
@@ -2,22 +2,25 @@
 # for more details
 'context-menu':
   'atom-text-editor': [
-    {
-      'label': 'Git Gui'
-      'command': 'git-tools:git-gui'
-    },
-    {
-     'label': 'Git Gui Blame'
-     'command': 'git-tools:git-gui-blame'
-    },
-    {
-      'label': 'Gitk'
-      'command': 'git-tools:gitk'
-    },
-    {
-      'label': 'Gitk Current File'
-      'command': 'git-tools:gitk-current-file'
-    }
+     'label': 'Git Tools'
+     'submenu':[
+       {
+         'label': 'Git Gui'
+         'command': 'git-tools:git-gui'
+       },
+       {
+         'label': 'Git Gui Blame'
+         'command': 'git-tools:git-gui-blame'
+       },
+       {
+         'label': 'Gitk'
+         'command': 'git-tools:gitk'
+       },
+       {
+         'label': 'Gitk Current File'
+         'command': 'git-tools:gitk-current-file'
+       }
+    ]
   ]
 'menu': [
   {

--- a/menus/git-tools.cson
+++ b/menus/git-tools.cson
@@ -7,6 +7,10 @@
       'command': 'git-tools:git-gui'
     },
     {
+     'label': 'Git Gui Blame'
+     'command': 'git-tools:git-gui-blame'
+    },
+    {
       'label': 'Gitk'
       'command': 'git-tools:gitk'
     },
@@ -24,6 +28,10 @@
         {
           'label': 'Git Gui'
           'command': 'git-tools:git-gui'
+        },
+        {
+          'label': 'Git Gui Blame'
+          'command': 'git-tools:git-gui-blame'
         },
         {
           'label': 'Gitk'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "activationCommands": {
     "atom-workspace": [
       "git-tools:git-gui",
+      "git-tools:git-gui-blame",
       "git-tools:gitk",
       "git-tools:gitk-current-file"
     ]

--- a/package.json
+++ b/package.json
@@ -21,5 +21,15 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+
+  "configSchema": {
+    "blameCursorNotification": {
+      "title": "Show notification of used line if multiple cursors are present",
+      "description": "This will display a notification of the used line for the \"Git Gui Blame\"-command.",
+      "type": "boolean",
+      "default": true,
+      "order": 1
+    }
+  }
 }


### PR DESCRIPTION
Added an option to use "git gui blame"-command centering on the line with the current cursor position.
- supports notification over used line if multiple cursors are used.
- context menu sub-group to avoid option spamming
